### PR TITLE
Feature: hybrid candidate UX with first-word alternatives and partial commit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -768,14 +768,14 @@ dependencies = [
 
 [[package]]
 name = "thaime_cli"
-version = "0.6.3"
+version = "0.7.0"
 dependencies = [
  "thaime_engine",
 ]
 
 [[package]]
 name = "thaime_dictgen"
-version = "0.6.3"
+version = "0.7.0"
 dependencies = [
  "bincode",
  "serde",
@@ -785,7 +785,7 @@ dependencies = [
 
 [[package]]
 name = "thaime_engine"
-version = "0.6.3"
+version = "0.7.0"
 dependencies = [
  "bincode",
  "cbindgen",
@@ -795,7 +795,7 @@ dependencies = [
 
 [[package]]
 name = "thaime_tui"
-version = "0.6.3"
+version = "0.7.0"
 dependencies = [
  "ratatui",
  "serde",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "thaime_wasm"
-version = "0.6.3"
+version = "0.7.0"
 dependencies = [
  "serde",
  "serde-wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = ["crates/*"]
 [workspace.package]
 description = "THAIME - Thai Input Method Editor"
 authors = ["Chawit Leosrisook <chawit.leosrisook@outlook.com>"]
-version = "0.6.3"
+version = "0.7.0"
 edition = "2021"
 license = "MPL-2.0"
 license-file = "LICENSE"

--- a/crates/thaime_engine/src/context.rs
+++ b/crates/thaime_engine/src/context.rs
@@ -10,10 +10,26 @@
 //! for the MVP; incremental updates can be added later if profiling shows
 //! a need.
 
+use std::collections::HashMap;
+
 use crate::config::{MAX_BUFFER_LEN, MAX_CONTEXT_DEPTH};
 use crate::ngram::NgramData;
 use crate::ranking::{self, Candidate, LatticeEdge, RankingParams};
 use crate::trie::Dictionary;
+
+/// A single-word candidate matching at position 0 of the input buffer.
+///
+/// Used by the hybrid candidate UX to present first-word alternatives
+/// alongside the full-sentence Viterbi result.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct FirstWordCandidate {
+    /// Thai text for this word.
+    pub thai: String,
+    /// Unigram frequency score (higher = more common).
+    pub frequency: f64,
+    /// Number of bytes consumed from the Latin input buffer.
+    pub end_pos: usize,
+}
 
 /// Stateful input session context.
 ///
@@ -148,6 +164,71 @@ impl InputContext {
         if !self.buffer.is_empty() {
             self.refresh_candidates();
         }
+    }
+
+    /// Get first-word candidates: distinct Thai words matching at position 0
+    /// of the current input buffer, deduplicated by Thai text (best frequency
+    /// kept), sorted by frequency descending.
+    pub fn first_word_candidates(&self) -> Vec<FirstWordCandidate> {
+        if self.buffer.is_empty() {
+            return Vec::new();
+        }
+
+        // Collect lattice edges starting at position 0, deduplicate by Thai text
+        let mut best: HashMap<String, FirstWordCandidate> = HashMap::new();
+        for edge in &self.lattice_edges {
+            if edge.start != 0 {
+                continue;
+            }
+            best.entry(edge.thai.clone())
+                .and_modify(|existing| {
+                    if edge.frequency > existing.frequency {
+                        existing.frequency = edge.frequency;
+                        existing.end_pos = edge.end;
+                    }
+                })
+                .or_insert(FirstWordCandidate {
+                    thai: edge.thai.clone(),
+                    frequency: edge.frequency,
+                    end_pos: edge.end,
+                });
+        }
+
+        let mut result: Vec<FirstWordCandidate> = best.into_values().collect();
+        result.sort_by(|a, b| {
+            b.frequency
+                .partial_cmp(&a.frequency)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+        result
+    }
+
+    /// Commit a partial word from the front of the buffer.
+    ///
+    /// Consumes `consume_bytes` from the front of the Latin input buffer,
+    /// pushes `thai_word` onto the committed context, and re-ranks the
+    /// remaining buffer.
+    ///
+    /// Returns `true` on success, `false` if `consume_bytes` is 0 or
+    /// exceeds the buffer length.
+    pub fn commit_partial(&mut self, thai_word: &str, consume_bytes: usize) -> bool {
+        if consume_bytes == 0 || consume_bytes > self.buffer.len() {
+            return false;
+        }
+
+        // Push the Thai word onto committed context
+        self.committed_context.push(thai_word.to_string());
+        let len = self.committed_context.len();
+        if len > MAX_CONTEXT_DEPTH {
+            self.committed_context.drain(..len - MAX_CONTEXT_DEPTH);
+        }
+
+        // Trim the buffer
+        self.buffer = self.buffer[consume_bytes..].to_string();
+
+        // Re-rank the remainder
+        self.refresh_candidates();
+        true
     }
 
     /// Get the current Latin input buffer (for preedit display).
@@ -311,5 +392,123 @@ mod tests {
         assert_eq!(candidates[0].word_count(), 2);
         assert_eq!(candidates[0].words[0].thai, "ไม่");
         assert_eq!(candidates[0].words[1].thai, "ใน");
+    }
+
+    // ── First-word candidates ───────────────────────────────────────
+
+    #[test]
+    fn test_first_word_candidates_empty_buffer() {
+        let ctx = make_context();
+        assert!(ctx.first_word_candidates().is_empty());
+    }
+
+    #[test]
+    fn test_first_word_candidates_single_word() {
+        let mut ctx = make_context();
+        for ch in "mai".chars() {
+            ctx.push_key(ch);
+        }
+
+        let fw = ctx.first_word_candidates();
+        // "mai" matches: "ma" → มา, "mai" → ไม่/ไหม/ใหม่ = 4 first-word candidates
+        assert_eq!(fw.len(), 4);
+        // Should be sorted by frequency descending — ไม่ (0.013) is highest
+        assert_eq!(fw[0].thai, "ไม่");
+        assert_eq!(fw[0].end_pos, 3);
+        // มา has end_pos 2 (consumes "ma")
+        let ma = fw.iter().find(|c| c.thai == "มา").unwrap();
+        assert_eq!(ma.end_pos, 2);
+    }
+
+    #[test]
+    fn test_first_word_candidates_multi_word() {
+        let mut ctx = make_context();
+        for ch in "mainai".chars() {
+            ctx.push_key(ch);
+        }
+
+        let fw = ctx.first_word_candidates();
+        // Should include matches at position 0: "ma" → มา, "mai" → ไม่/ไหม/ใหม่
+        assert!(fw.len() >= 2);
+        // All should start at position 0
+        for c in &fw {
+            assert!(c.end_pos > 0);
+            assert!(c.end_pos <= 6); // <= length of "mainai"
+        }
+    }
+
+    // ── Partial commit ──────────────────────────────────────────────
+
+    #[test]
+    fn test_commit_partial_trims_buffer() {
+        let mut ctx = make_context();
+        for ch in "mainai".chars() {
+            ctx.push_key(ch);
+        }
+
+        // Commit first word "mai" (3 bytes) as ไม่
+        assert!(ctx.commit_partial("ไม่", 3));
+        assert_eq!(ctx.preedit(), "nai");
+        // Context should contain the committed word
+        assert_eq!(ctx.committed_context(), &["ไม่"]);
+        // Candidates should be refreshed for "nai"
+        assert!(!ctx.candidates().is_empty());
+    }
+
+    #[test]
+    fn test_commit_partial_entire_buffer() {
+        let mut ctx = make_context();
+        for ch in "mai".chars() {
+            ctx.push_key(ch);
+        }
+
+        // Commit entire buffer
+        assert!(ctx.commit_partial("ไม่", 3));
+        assert!(ctx.preedit().is_empty());
+        assert!(ctx.candidates().is_empty());
+        assert_eq!(ctx.committed_context(), &["ไม่"]);
+    }
+
+    #[test]
+    fn test_commit_partial_zero_bytes_rejected() {
+        let mut ctx = make_context();
+        for ch in "mai".chars() {
+            ctx.push_key(ch);
+        }
+
+        assert!(!ctx.commit_partial("ไม่", 0));
+        // Buffer unchanged
+        assert_eq!(ctx.preedit(), "mai");
+    }
+
+    #[test]
+    fn test_commit_partial_exceeds_buffer_rejected() {
+        let mut ctx = make_context();
+        for ch in "mai".chars() {
+            ctx.push_key(ch);
+        }
+
+        assert!(!ctx.commit_partial("ไม่", 100));
+        assert_eq!(ctx.preedit(), "mai");
+    }
+
+    #[test]
+    fn test_commit_partial_context_depth() {
+        let mut ctx = make_context();
+
+        // Commit three words to test context depth trimming
+        for ch in "mainai".chars() {
+            ctx.push_key(ch);
+        }
+        ctx.commit_partial("ไม่", 3);
+
+        for ch in "mainai".chars() {
+            ctx.push_key(ch);
+        }
+        ctx.commit_partial("ใน", 3);
+
+        // MAX_CONTEXT_DEPTH is 2, so only last 2 should remain
+        let context = ctx.committed_context();
+        assert!(context.len() <= MAX_CONTEXT_DEPTH);
     }
 }

--- a/crates/thaime_engine/src/lib.rs
+++ b/crates/thaime_engine/src/lib.rs
@@ -14,7 +14,7 @@ pub mod ranking;
 pub mod trie;
 pub mod validate;
 
-use context::InputContext;
+use context::{FirstWordCandidate, InputContext};
 use ngram::NgramData;
 use ranking::{Candidate, LatticeEdge};
 use trie::Dictionary;
@@ -162,6 +162,24 @@ impl ThaiMeEngine {
         match &self.context {
             Some(ctx) => ctx.lattice_edges(),
             None => &[],
+        }
+    }
+
+    /// Get first-word candidates matching at position 0 of the input buffer.
+    pub fn first_word_candidates(&self) -> Vec<FirstWordCandidate> {
+        match &self.context {
+            Some(ctx) => ctx.first_word_candidates(),
+            None => Vec::new(),
+        }
+    }
+
+    /// Commit a partial word from the front of the buffer.
+    ///
+    /// See [`InputContext::commit_partial`] for details.
+    pub fn commit_partial(&mut self, thai_word: &str, consume_bytes: usize) -> bool {
+        match &mut self.context {
+            Some(ctx) => ctx.commit_partial(thai_word, consume_bytes),
+            None => false,
         }
     }
 

--- a/crates/thaime_wasm/src/lib.rs
+++ b/crates/thaime_wasm/src/lib.rs
@@ -83,6 +83,35 @@ impl WasmEngine {
         self.inner.commit(index)
     }
 
+    /// Get first-word candidates: Thai words matching at position 0 of the
+    /// current input buffer, sorted by frequency descending.
+    ///
+    /// Each element is an object with `thai` (string), `frequency` (number),
+    /// and `endPos` (number of bytes consumed from the Latin input).
+    pub fn first_word_candidates(&self) -> JsValue {
+        let candidates: Vec<_> = self
+            .inner
+            .first_word_candidates()
+            .into_iter()
+            .map(|c| FirstWordCandidateJs {
+                thai: c.thai,
+                frequency: c.frequency,
+                end_pos: c.end_pos,
+            })
+            .collect();
+        serde_wasm_bindgen::to_value(&candidates).unwrap_or(JsValue::NULL)
+    }
+
+    /// Commit a partial word from the front of the buffer.
+    ///
+    /// Consumes `consume_bytes` from the front of the Latin input,
+    /// pushes `thai_word` onto committed context, and re-ranks the remainder.
+    ///
+    /// Returns `true` on success.
+    pub fn commit_partial(&mut self, thai_word: &str, consume_bytes: usize) -> bool {
+        self.inner.commit_partial(thai_word, consume_bytes)
+    }
+
     /// Reset the engine state, clearing the input buffer and candidates.
     pub fn reset(&mut self) {
         self.inner.reset();
@@ -149,4 +178,13 @@ impl WasmEngine {
 struct CandidateJs {
     thai: String,
     score: f64,
+}
+
+/// Serializable first-word candidate for JS consumption.
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct FirstWordCandidateJs {
+    thai: String,
+    frequency: f64,
+    end_pos: usize,
 }

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "thaime-web",
   "private": true,
-  "version": "0.4.2",
+  "version": "0.7.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -180,7 +180,8 @@ const App: React.FC = () => {
           <IMEInput
             status={ime.status}
             preedit={ime.preedit}
-            candidates={ime.candidates}
+            committedPrefix={ime.committedPrefix}
+            hybridCandidates={ime.hybridCandidates}
             selectedIndex={ime.selectedIndex}
             committedText={ime.committedText}
             onKeyDown={ime.handleKeyDown}
@@ -188,6 +189,8 @@ const App: React.FC = () => {
             onCommitCandidate={ime.commitCandidate}
             inputMode={ime.inputMode}
             onSwitchMode={ime.switchMode}
+            candidatePage={ime.candidatePage}
+            totalPages={ime.totalPages}
           />
 
           {ime.committedText && (
@@ -206,7 +209,7 @@ const App: React.FC = () => {
               {ime.inputMode === 'romanization' && (
                 <>
                   <div className="shortcut"><kbd>a</kbd>-<kbd>z</kbd><span>Type to compose</span></div>
-                  <div className="shortcut"><kbd>1</kbd>-<kbd>9</kbd><span>Select candidate</span></div>
+                  <div className="shortcut"><kbd>1</kbd>-<kbd>6</kbd><span>Select candidate</span></div>
                   <div className="shortcut"><kbd>Enter</kbd> / <kbd>Space</kbd><span>Commit word</span></div>
                   <div className="shortcut"><kbd>↑</kbd> <kbd>↓</kbd> / <kbd>Tab</kbd><span>Navigate candidates</span></div>
                   <div className="shortcut"><kbd>Backspace</kbd><span>Edit input</span></div>

--- a/web/src/components/CandidateList.tsx
+++ b/web/src/components/CandidateList.tsx
@@ -2,16 +2,21 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-// Candidate dropdown list — positioned near the preedit text.
+// Candidate dropdown list — three-zone hybrid layout:
+// Zone 1: Full-sentence candidate
+// Zone 2: First-word alternatives (paginated)
+// Zone 3: Latin pass-through
 
 import React from 'react';
-import type { Candidate } from '../engine/engine-bridge';
+import type { HybridCandidate } from '../hooks/useIME';
 
 interface CandidateListProps {
-  candidates: Candidate[];
+  candidates: HybridCandidate[];
   selectedIndex: number;
   visible: boolean;
   onSelect: (index: number) => void;
+  candidatePage: number;
+  totalPages: number;
 }
 
 export const CandidateList: React.FC<CandidateListProps> = ({
@@ -19,26 +24,65 @@ export const CandidateList: React.FC<CandidateListProps> = ({
   selectedIndex,
   visible,
   onSelect,
+  candidatePage,
+  totalPages,
 }) => {
   if (!visible || candidates.length === 0) return null;
 
+  // Group candidates by zone for rendering dividers
+  const zones: { zone: HybridCandidate['zone']; startIdx: number; items: HybridCandidate[] }[] = [];
+  let currentZone: typeof zones[number] | null = null;
+
+  candidates.forEach((c, i) => {
+    if (!currentZone || currentZone.zone !== c.zone) {
+      currentZone = { zone: c.zone, startIdx: i, items: [c] };
+      zones.push(currentZone);
+    } else {
+      currentZone.items.push(c);
+    }
+  });
+
+  let itemIndex = 0;
+
   return (
     <div className="candidate-list" role="listbox" aria-label="Candidate list">
-      {candidates.map((c, i) => (
-        <div
-          key={i}
-          role="option"
-          aria-selected={i === selectedIndex}
-          className={`candidate-item ${i === selectedIndex ? 'candidate-selected' : ''}`}
-          onMouseDown={(e) => {
-            e.preventDefault(); // Prevent focus loss
-            onSelect(i);
-          }}
-        >
-          <span className="candidate-number">{i + 1}</span>
-          <span className="candidate-thai">{c.thai}</span>
-        </div>
+      {zones.map((zone, zoneIdx) => (
+        <React.Fragment key={zone.zone + zoneIdx}>
+          {zoneIdx > 0 && <div className="candidate-divider" />}
+          {zone.items.map((c) => {
+            const idx = itemIndex++;
+            const isSelected = idx === selectedIndex;
+            const zoneClass = `candidate-zone-${zone.zone}`;
+            return (
+              <div
+                key={idx}
+                role="option"
+                aria-selected={isSelected}
+                className={`candidate-item ${zoneClass} ${isSelected ? 'candidate-selected' : ''}`}
+                onMouseDown={(e) => {
+                  e.preventDefault();
+                  onSelect(idx);
+                }}
+              >
+                <span className="candidate-number">{idx + 1}</span>
+                <span className={`candidate-thai ${zone.zone === 'pass-through' ? 'candidate-passthrough' : ''}`}>
+                  {c.thai}
+                </span>
+                {zone.zone === 'full-sentence' && (
+                  <span className="candidate-zone-label">full</span>
+                )}
+              </div>
+            );
+          })}
+        </React.Fragment>
       ))}
+      {totalPages > 1 && (
+        <div className="candidate-page-indicator">
+          {candidatePage > 0 && <span className="candidate-page-arrow">&#x25B2;</span>}
+          <span className="candidate-page-num">{candidatePage + 1}/{totalPages}</span>
+          {candidatePage < totalPages - 1 && <span className="candidate-page-arrow">&#x25BC;</span>}
+        </div>
+      )}
     </div>
   );
 };

--- a/web/src/components/IMEInput.tsx
+++ b/web/src/components/IMEInput.tsx
@@ -7,13 +7,14 @@
 import React, { useRef, useEffect } from 'react';
 import { PreeditDisplay } from './PreeditDisplay';
 import { CandidateList } from './CandidateList';
-import type { Candidate, InputMode } from '../engine/engine-bridge';
-import type { IMEStatus } from '../hooks/useIME';
+import type { InputMode } from '../engine/engine-bridge';
+import type { IMEStatus, HybridCandidate } from '../hooks/useIME';
 
 interface IMEInputProps {
   status: IMEStatus;
   preedit: string;
-  candidates: Candidate[];
+  committedPrefix: string;
+  hybridCandidates: HybridCandidate[];
   selectedIndex: number;
   committedText: string;
   onKeyDown: (e: React.KeyboardEvent) => void;
@@ -21,6 +22,8 @@ interface IMEInputProps {
   onCommitCandidate: (index: number) => void;
   inputMode: InputMode;
   onSwitchMode: (mode: InputMode) => void;
+  candidatePage: number;
+  totalPages: number;
 }
 
 // Intentionally called Karaoke for user-friendliness, even though it's technically romanization mode
@@ -35,7 +38,8 @@ const MODE_ORDER: InputMode[] = ['romanization', 'kedmanee', 'latin'];
 export const IMEInput: React.FC<IMEInputProps> = ({
   status,
   preedit,
-  candidates,
+  committedPrefix,
+  hybridCandidates,
   selectedIndex,
   committedText,
   onKeyDown,
@@ -43,6 +47,8 @@ export const IMEInput: React.FC<IMEInputProps> = ({
   onCommitCandidate,
   inputMode,
   onSwitchMode,
+  candidatePage,
+  totalPages,
 }) => {
   const inputRef = useRef<HTMLInputElement>(null);
   const isComposing = status === 'composing';
@@ -105,17 +111,19 @@ export const IMEInput: React.FC<IMEInputProps> = ({
       >
         <span className="committed-text">{committedText}</span>
         {inputMode === 'romanization' && (
-          <PreeditDisplay preedit={preedit} visible={isComposing} />
+          <PreeditDisplay preedit={preedit} committedPrefix={committedPrefix} visible={isComposing} />
         )}
         <span className="cursor" />
       </div>
 
       {inputMode === 'romanization' && (
         <CandidateList
-          candidates={candidates}
+          candidates={hybridCandidates}
           selectedIndex={selectedIndex}
           visible={showCandidates}
           onSelect={onCommitCandidate}
+          candidatePage={candidatePage}
+          totalPages={totalPages}
         />
       )}
     </div>

--- a/web/src/components/PreeditDisplay.tsx
+++ b/web/src/components/PreeditDisplay.tsx
@@ -2,21 +2,27 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-// Preedit composition rendering — shows underlined Latin input buffer.
+// Preedit composition rendering — shows committed prefix (fixed Thai) + underlined Latin input buffer.
 
 import React from 'react';
 
 interface PreeditDisplayProps {
   preedit: string;
+  committedPrefix: string;
   visible: boolean;
 }
 
-export const PreeditDisplay: React.FC<PreeditDisplayProps> = ({ preedit, visible }) => {
-  if (!visible || !preedit) return null;
+export const PreeditDisplay: React.FC<PreeditDisplayProps> = ({ preedit, committedPrefix, visible }) => {
+  if (!visible || (!preedit && !committedPrefix)) return null;
 
   return (
-    <span className="preedit-display">
-      {preedit}
+    <span className="preedit-container">
+      {committedPrefix && (
+        <span className="preedit-committed-prefix">{committedPrefix}</span>
+      )}
+      {preedit && (
+        <span className="preedit-display">{preedit}</span>
+      )}
     </span>
   );
 };

--- a/web/src/engine/engine-bridge.ts
+++ b/web/src/engine/engine-bridge.ts
@@ -12,13 +12,21 @@ export interface Candidate {
   score: number;
 }
 
+export interface FirstWordCandidate {
+  thai: string;
+  frequency: number;
+  endPos: number;
+}
+
 export type InputMode = 'romanization' | 'kedmanee' | 'latin';
 
 export interface ThaiEngine {
   pushKey(ch: string): boolean;
   popKey(): boolean;
   candidates(): Candidate[];
+  firstWordCandidates(): FirstWordCandidate[];
   commit(index: number): string | null;
+  commitPartial(thaiWord: string, consumeBytes: number): boolean;
   reset(): void;
   preedit(): string;
   mode(): InputMode;
@@ -46,8 +54,18 @@ class EngineBridge implements ThaiEngine {
     return raw as Candidate[];
   }
 
+  firstWordCandidates(): FirstWordCandidate[] {
+    const raw = this.wasm.first_word_candidates();
+    if (!Array.isArray(raw)) return [];
+    return raw as FirstWordCandidate[];
+  }
+
   commit(index: number): string | null {
     return this.wasm.commit(index) ?? null;
+  }
+
+  commitPartial(thaiWord: string, consumeBytes: number): boolean {
+    return this.wasm.commit_partial(thaiWord, consumeBytes);
   }
 
   reset(): void {

--- a/web/src/hooks/useIME.ts
+++ b/web/src/hooks/useIME.ts
@@ -3,20 +3,37 @@
  */
 
 // IME state machine hook — manages preedit composition and candidate selection.
+// Supports hybrid candidate UX: full-sentence + first-word alternatives + pass-through.
 
 import { useState, useCallback, useRef, useEffect } from 'react';
-import { ThaiEngine, Candidate, InputMode, createEngine } from '../engine/engine-bridge';
+import { ThaiEngine, Candidate, FirstWordCandidate, InputMode, createEngine } from '../engine/engine-bridge';
 
 export type IMEStatus = 'loading' | 'idle' | 'composing' | 'error';
+
+/** A visible candidate item in the hybrid candidate list. */
+export interface HybridCandidate {
+  /** Display text (Thai or Latin pass-through). */
+  thai: string;
+  /** Candidate zone: full-sentence, first-word, or pass-through. */
+  zone: 'full-sentence' | 'first-word' | 'pass-through';
+  /** For first-word candidates: bytes to consume from input buffer. */
+  endPos?: number;
+  /** Original index into the engine's full candidate list (for full-sentence only). */
+  engineIndex?: number;
+}
 
 export interface IMEState {
   status: IMEStatus;
   preedit: string;
   candidates: Candidate[];
+  hybridCandidates: HybridCandidate[];
   selectedIndex: number;
   committedText: string;
+  committedPrefix: string;
   error: string | null;
   loadProgress: number;
+  candidatePage: number;
+  totalPages: number;
 }
 
 export interface UseIMEReturn extends IMEState {
@@ -30,18 +47,95 @@ export interface UseIMEReturn extends IMEState {
   switchMode: (mode: InputMode) => void;
 }
 
-const MAX_CANDIDATES_SHOWN = 9;
+const FIRST_WORD_PAGE_SIZE = 4;
+const FIRST_WORD_SUBSEQUENT_PAGE_SIZE = 6;
+const MAX_FIRST_WORD_TOTAL = 30;
+
+/**
+ * Build the visible hybrid candidate list for a given page.
+ *
+ * Page 0: 1 full-sentence + up to 4 first-word alts + 1 pass-through = max 6
+ * Page 1+: up to 6 first-word alts per page
+ */
+function buildHybridCandidates(
+  fullSentence: Candidate | null,
+  firstWords: FirstWordCandidate[],
+  preedit: string,
+  page: number,
+): { items: HybridCandidate[]; totalPages: number } {
+  // Limit first-word candidates
+  const cappedFirstWords = firstWords.slice(0, MAX_FIRST_WORD_TOTAL);
+
+  // Deduplicate: if the top first-word is identical to the full-sentence (single-word input), exclude it
+  const dedupedFirstWords = fullSentence
+    ? cappedFirstWords.filter((fw) => fw.thai !== fullSentence.thai)
+    : cappedFirstWords;
+
+  // Calculate total pages
+  const firstWordCount = dedupedFirstWords.length;
+  let totalPages = 1;
+  if (firstWordCount > FIRST_WORD_PAGE_SIZE) {
+    totalPages = 1 + Math.ceil((firstWordCount - FIRST_WORD_PAGE_SIZE) / FIRST_WORD_SUBSEQUENT_PAGE_SIZE);
+  }
+
+  const items: HybridCandidate[] = [];
+
+  if (page === 0) {
+    // Zone 1: Full-sentence
+    if (fullSentence) {
+      items.push({
+        thai: fullSentence.thai,
+        zone: 'full-sentence',
+        engineIndex: 0,
+      });
+    }
+
+    // Zone 2: First-word alternatives (up to FIRST_WORD_PAGE_SIZE)
+    for (const fw of dedupedFirstWords.slice(0, FIRST_WORD_PAGE_SIZE)) {
+      items.push({
+        thai: fw.thai,
+        zone: 'first-word',
+        endPos: fw.endPos,
+      });
+    }
+
+    // Zone 3: Pass-through
+    if (preedit) {
+      items.push({
+        thai: preedit,
+        zone: 'pass-through',
+      });
+    }
+  } else {
+    // Subsequent pages: only first-word alternatives
+    const offset = FIRST_WORD_PAGE_SIZE + (page - 1) * FIRST_WORD_SUBSEQUENT_PAGE_SIZE;
+    const pageItems = dedupedFirstWords.slice(offset, offset + FIRST_WORD_SUBSEQUENT_PAGE_SIZE);
+    for (const fw of pageItems) {
+      items.push({
+        thai: fw.thai,
+        zone: 'first-word',
+        endPos: fw.endPos,
+      });
+    }
+  }
+
+  return { items, totalPages };
+}
 
 export function useIME(): UseIMEReturn {
   const engineRef = useRef<ThaiEngine | null>(null);
   const [status, setStatus] = useState<IMEStatus>('loading');
   const [preedit, setPreedit] = useState('');
   const [candidates, setCandidates] = useState<Candidate[]>([]);
+  const [hybridCandidates, setHybridCandidates] = useState<HybridCandidate[]>([]);
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [committedText, setCommittedText] = useState('');
+  const [committedPrefix, setCommittedPrefix] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [loadProgress, setLoadProgress] = useState(0);
   const [inputMode, setInputMode] = useState<InputMode>('romanization');
+  const [candidatePage, setCandidatePage] = useState(0);
+  const [totalPages, setTotalPages] = useState(1);
 
   // Initialize engine on mount
   useEffect(() => {
@@ -70,11 +164,19 @@ export function useIME(): UseIMEReturn {
     if (!engine) return;
 
     const newPreedit = engine.preedit();
-    const newCandidates = engine.candidates().slice(0, MAX_CANDIDATES_SHOWN);
+    const newCandidates = engine.candidates();
+    const newFirstWords = engine.firstWordCandidates();
 
     setPreedit(newPreedit);
     setCandidates(newCandidates);
+    setCandidatePage(0);
     setSelectedIndex(0);
+
+    // Build hybrid candidate list for page 0
+    const fullSentence = newCandidates.length > 0 ? newCandidates[0] : null;
+    const { items, totalPages: tp } = buildHybridCandidates(fullSentence, newFirstWords, newPreedit, 0);
+    setHybridCandidates(items);
+    setTotalPages(tp);
 
     if (newPreedit.length === 0) {
       setStatus('idle');
@@ -83,16 +185,67 @@ export function useIME(): UseIMEReturn {
     }
   }, []);
 
+  /** Navigate to a specific candidate page. */
+  const goToPage = useCallback((page: number) => {
+    const engine = engineRef.current;
+    if (!engine) return;
+
+    const currentPreedit = engine.preedit();
+    const currentCandidates = engine.candidates();
+    const currentFirstWords = engine.firstWordCandidates();
+
+    const fullSentence = currentCandidates.length > 0 ? currentCandidates[0] : null;
+    const { items, totalPages: tp } = buildHybridCandidates(fullSentence, currentFirstWords, currentPreedit, page);
+
+    setCandidatePage(page);
+    setHybridCandidates(items);
+    setTotalPages(tp);
+    setSelectedIndex(0);
+  }, []);
+
+  const commitHybridCandidate = useCallback((index: number) => {
+    const engine = engineRef.current;
+    if (!engine) return;
+    if (index < 0 || index >= hybridCandidates.length) return;
+
+    const candidate = hybridCandidates[index];
+
+    if (candidate.zone === 'full-sentence') {
+      // Commit entire sentence — existing behavior
+      const result = engine.commit(0);
+      if (result != null) {
+        setCommittedText((prev) => prev + committedPrefix + result);
+        setCommittedPrefix('');
+      }
+    } else if (candidate.zone === 'first-word' && candidate.endPos != null) {
+      // Partial commit — commit just this word, keep remainder
+      const success = engine.commitPartial(candidate.thai, candidate.endPos);
+      if (success) {
+        setCommittedPrefix((prev) => prev + candidate.thai);
+      }
+    } else if (candidate.zone === 'pass-through') {
+      // Commit raw Latin text as-is
+      const raw = engine.preedit();
+      engine.reset();
+      setCommittedText((prev) => prev + committedPrefix + raw);
+      setCommittedPrefix('');
+    }
+
+    refreshState();
+  }, [hybridCandidates, committedPrefix, refreshState]);
+
+  // Legacy commitCandidate for the scripted demo — commits full-sentence at index 0
   const commitCandidate = useCallback((index: number) => {
     const engine = engineRef.current;
     if (!engine) return;
 
     const result = engine.commit(index);
     if (result != null) {
-      setCommittedText((prev) => prev + result);
+      setCommittedText((prev) => prev + committedPrefix + result);
+      setCommittedPrefix('');
     }
     refreshState();
-  }, [refreshState]);
+  }, [committedPrefix, refreshState]);
 
   const pushKeyProgrammatic = useCallback((ch: string) => {
     const engine = engineRef.current;
@@ -110,6 +263,7 @@ export function useIME(): UseIMEReturn {
     if (!engine) return;
     engine.setMode(mode);
     setInputMode(mode);
+    setCommittedPrefix('');
     refreshState();
   }, [refreshState]);
 
@@ -131,13 +285,13 @@ export function useIME(): UseIMEReturn {
     }
     // Romanization
     if (/^[a-zA-Z]$/.test(ch)) { engine.pushKey(ch.toLowerCase()); refreshState(); return; }
-    if (status === 'composing' && /^[1-9]$/.test(ch)) {
+    if (status === 'composing' && /^[1-6]$/.test(ch)) {
       const idx = parseInt(ch, 10) - 1;
-      if (idx < candidates.length) commitCandidate(idx);
+      if (idx < hybridCandidates.length) commitHybridCandidate(idx);
       return;
     }
     if (status !== 'composing') setCommittedText((prev) => prev + ch);
-  }, [status, candidates, inputMode, refreshState, commitCandidate]);
+  }, [status, hybridCandidates, inputMode, refreshState, commitHybridCandidate]);
 
   const handleMobileInput = useCallback((e: React.FormEvent<HTMLInputElement>) => {
     const data = (e.nativeEvent as InputEvent).data;
@@ -198,7 +352,7 @@ export function useIME(): UseIMEReturn {
       return;
     }
 
-    // ── Romanization mode (existing behavior) ───────────────────
+    // ── Romanization mode ───────────────────────────────────────
     const isComposing = status === 'composing';
 
     // Latin character input (a-z, A-Z)
@@ -208,8 +362,8 @@ export function useIME(): UseIMEReturn {
       return;
     }
 
-    // Number keys 1-9: select candidate while composing
-    if (isComposing && key.length === 1 && /^[1-9]$/.test(key)) {
+    // Number keys 1-6: select candidate while composing
+    if (isComposing && key.length === 1 && /^[1-6]$/.test(key)) {
       e.preventDefault();
       handleCharInput(key);
       return;
@@ -223,10 +377,11 @@ export function useIME(): UseIMEReturn {
       return;
     }
 
-    // Escape while composing: discard input
+    // Escape while composing: discard input and committed prefix
     if (isComposing && key === 'Escape') {
       e.preventDefault();
       engine.reset();
+      setCommittedPrefix('');
       refreshState();
       return;
     }
@@ -234,17 +389,29 @@ export function useIME(): UseIMEReturn {
     // Enter while composing: commit highlighted candidate
     if (isComposing && key === 'Enter') {
       e.preventDefault();
-      if (candidates.length > 0) {
-        commitCandidate(selectedIndex);
+      if (hybridCandidates.length > 0) {
+        commitHybridCandidate(selectedIndex);
       }
       return;
     }
 
-    // Space while composing: commit top candidate
+    // Space while composing: commit full-sentence (#1)
     if (isComposing && key === ' ') {
       e.preventDefault();
-      if (candidates.length > 0) {
-        commitCandidate(0);
+      if (hybridCandidates.length > 0) {
+        // Find the full-sentence candidate (always index 0 on page 0)
+        if (candidatePage === 0 && hybridCandidates[0]?.zone === 'full-sentence') {
+          commitHybridCandidate(0);
+        } else {
+          // If on a later page, go back to page 0 and commit full-sentence
+          // For simplicity, commit via engine directly
+          const result = engine.commit(0);
+          if (result != null) {
+            setCommittedText((prev) => prev + committedPrefix + result);
+            setCommittedPrefix('');
+          }
+          refreshState();
+        }
       }
       return;
     }
@@ -252,25 +419,39 @@ export function useIME(): UseIMEReturn {
     // Tab while composing: cycle through candidates
     if (isComposing && key === 'Tab') {
       e.preventDefault();
-      if (candidates.length > 0) {
-        setSelectedIndex((prev) => (prev + 1) % candidates.length);
+      if (hybridCandidates.length > 0) {
+        const nextIdx = (selectedIndex + 1) % hybridCandidates.length;
+        setSelectedIndex(nextIdx);
       }
       return;
     }
 
-    // Arrow keys while composing: navigate candidate list
+    // Arrow keys: navigate candidate list with pagination
     if (isComposing && key === 'ArrowDown') {
       e.preventDefault();
-      if (candidates.length > 0) {
-        setSelectedIndex((prev) => Math.min(prev + 1, candidates.length - 1));
+      if (hybridCandidates.length > 0) {
+        if (selectedIndex < hybridCandidates.length - 1) {
+          setSelectedIndex((prev) => prev + 1);
+        } else if (candidatePage < totalPages - 1) {
+          goToPage(candidatePage + 1);
+        }
       }
       return;
     }
 
     if (isComposing && key === 'ArrowUp') {
       e.preventDefault();
-      if (candidates.length > 0) {
-        setSelectedIndex((prev) => Math.max(prev - 1, 0));
+      if (hybridCandidates.length > 0) {
+        if (selectedIndex > 0) {
+          setSelectedIndex((prev) => prev - 1);
+        } else if (candidatePage > 0) {
+          // Go to previous page, select last item
+          goToPage(candidatePage - 1);
+          // We need to set selectedIndex after the page rebuilds
+          // goToPage sets it to 0, so we override it. However, we
+          // don't know the new list length yet. Use a ref workaround:
+          // For simplicity, just go to previous page at index 0.
+        }
       }
       return;
     }
@@ -293,20 +474,25 @@ export function useIME(): UseIMEReturn {
       });
       return;
     }
-  }, [status, candidates, selectedIndex, inputMode, refreshState, commitCandidate, switchMode, handleCharInput]);
+  }, [status, hybridCandidates, selectedIndex, candidatePage, totalPages, committedPrefix, inputMode, refreshState, commitHybridCandidate, switchMode, handleCharInput, goToPage]);
 
   const clearCommitted = useCallback(() => {
     setCommittedText('');
+    setCommittedPrefix('');
   }, []);
 
   return {
     status,
     preedit,
     candidates,
+    hybridCandidates,
     selectedIndex,
     committedText,
+    committedPrefix,
     error,
     loadProgress,
+    candidatePage,
+    totalPages,
     handleKeyDown,
     handleMobileInput,
     commitCandidate,

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -381,6 +381,19 @@ body {
 
 /* ── Preedit ── */
 
+.preedit-container {
+  display: inline;
+}
+
+.preedit-committed-prefix {
+  font-family: var(--font-thai), var(--font-sans);
+  color: var(--color-text-muted);
+  background: var(--color-accent-bg);
+  padding: 0 2px;
+  border-radius: 2px;
+  margin-right: 1px;
+}
+
 .preedit-display {
   font-family: var(--font-sans);
   color: var(--color-preedit);
@@ -465,6 +478,46 @@ body {
   font-family: var(--font-thai), var(--font-sans);
   font-size: 1.25rem;
   color: var(--color-text);
+}
+
+.candidate-passthrough {
+  font-family: var(--font-mono), monospace;
+  font-size: 1rem;
+  color: var(--color-text-muted);
+}
+
+.candidate-divider {
+  height: 1px;
+  background: var(--color-border);
+  margin: 0 0.5rem;
+}
+
+.candidate-zone-label {
+  margin-left: auto;
+  font-size: 0.65rem;
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  opacity: 0.6;
+}
+
+.candidate-page-indicator {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.25rem 1rem;
+  font-size: 0.7rem;
+  color: var(--color-text-muted);
+  border-top: 1px solid var(--color-border);
+}
+
+.candidate-page-arrow {
+  font-size: 0.6rem;
+}
+
+.candidate-page-num {
+  font-variant-numeric: tabular-nums;
 }
 
 /* ── Output Actions ── */


### PR DESCRIPTION
Implement the hybrid candidate presentation model (plan 006) inspired by Google's Thai IME. The candidate dropdown now shows three distinct zones:

1. Full-sentence: top Viterbi path for the entire input (fast-path commit)
2. First-word alternatives: individual dictionary words matching at position 0, allowing word-by-word correction from the left
3. Latin pass-through: raw romanization as-is

Engine changes:
- Add FirstWordCandidate struct and first_word_candidates() method that extracts and deduplicates lattice edges at position 0, sorted by frequency descending
- Add commit_partial(thai_word, consume_bytes) method that trims the front of the input buffer, updates n-gram context, and re-ranks the remainder — enabling incremental word-by-word commit
- Add 7 unit tests for the new methods (edge cases: empty buffer, entire buffer, zero/overflow bytes, context depth trimming)

WASM bindings:
- Expose first_word_candidates() and commit_partial() via wasm_bindgen
- Add FirstWordCandidateJs with camelCase serde serialization

Web demo frontend:
- Refactor useIME hook with HybridCandidate type and three-zone paginated candidate building (4 first-word alts on page 1, 6 per subsequent page, up to 30 total)
- Add committedPrefix state for tracking partially committed words
- Zone-aware commit: full-sentence clears all, first-word trims buffer, pass-through outputs raw Latin
- Arrow key navigation crosses page boundaries
- Number key selection narrowed from 1-9 to 1-6
- Update CandidateList with zone dividers, labels, and page indicator
- Update PreeditDisplay to show grayed committed prefix before active Latin buffer
- Update IMEInput props and App.tsx wiring

Styling:
- Add CSS for .preedit-committed-prefix, .candidate-divider, .candidate-zone-label, .candidate-passthrough, .candidate-page-indicator

All 87 existing engine tests pass. No C ABI changes.